### PR TITLE
Update bigerror to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "bigerror"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d841a61e15b10baa24d671701b4453933bc11b86239bc8d419a9f5e1aad5c9"
+checksum = "41bbd45a12df752099fe186d706f56b576371434515e732d1d1fec5fb5f17387"
 dependencies = [
  "error-stack",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1"
-bigerror = "0.7"
+bigerror = "0.8"
 dashmap = "5"
 futures = "0.3"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1"
-bigerror = "0.8"
+bigerror = ">=0.8"
 dashmap = "5"
 futures = "0.3"
 parking_lot = "0.12"


### PR DESCRIPTION
This updates the `bigerror` crate from `0.7` to `0.8`.