### PR TITLE
State Trait refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rex-sm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Hierarchical state machine"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rex-sm"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Hierarchical state machine"
 license = "MIT"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -97,7 +97,7 @@ where
     }
 
     #[must_use]
-    pub fn with_timeout_manager(
+    pub const fn with_timeout_manager(
         mut self,
         timeout_topic: <K::Message as RexMessage>::Topic,
     ) -> Self {
@@ -106,7 +106,7 @@ where
     }
 
     #[must_use]
-    pub fn with_tick_rate(mut self, tick_rate: Duration) -> Self {
+    pub const fn with_tick_rate(mut self, tick_rate: Duration) -> Self {
         self.tick_rate = Some(tick_rate);
         self
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use bigerror::{ConversionError, Report};
 use tokio::{
@@ -216,9 +216,9 @@ where
     fn default() -> Self {
         Self {
             notification_queue: NotificationQueue::new(),
-            signal_queue: Default::default(),
-            state_machines: Default::default(),
-            notification_processors: Default::default(),
+            signal_queue: Arc::default(),
+            state_machines: Vec::default(),
+            notification_processors: Vec::default(),
             timeout_topic: None,
             tick_rate: None,
             outbound_tx: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub trait State: fmt::Debug + Send + PartialEq + Copy {
 pub trait Kind: fmt::Debug + Send + Sized {
     type State: State<Input = Self::Input> + AsRef<Self>;
     type Input: Send + Sync + 'static + fmt::Debug;
+
     fn new_state(&self) -> Self::State;
     fn failed_state(&self) -> Self::State;
     fn completed_state(&self) -> Self::State;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,69 +32,23 @@ pub use timeout::Timeout;
 /// enumerations or enumerations whose variants only contain field-less enumerations; note that
 /// `Copy` is a required supertrait.
 pub trait State: fmt::Debug + Send + PartialEq + Copy {
-    fn get_kind(&self) -> &dyn Kind<State = Self>;
-    fn fail(&mut self)
-    where
-        Self: Sized,
-    {
-        *self = self.get_kind().failed_state();
-    }
-    fn complete(&mut self)
-    where
-        Self: Sized,
-    {
-        *self = self.get_kind().completed_state();
-    }
-    fn is_completed(&self) -> bool
-    where
-        Self: Sized,
-        for<'a> &'a Self: PartialEq<&'a Self>,
-    {
-        self == &self.get_kind().completed_state()
-    }
-
-    fn is_failed(&self) -> bool
-    where
-        Self: Sized,
-        for<'a> &'a Self: PartialEq<&'a Self>,
-    {
-        self == &self.get_kind().failed_state()
-    }
-    fn is_new(&self) -> bool
-    where
-        Self: Sized,
-        for<'a> &'a Self: PartialEq<&'a Self>,
-    {
-        self == &self.get_kind().new_state()
-    }
-
-    /// represents a state that will no longer change
-    fn is_terminal(&self) -> bool
-    where
-        Self: Sized,
-    {
-        self.is_failed() || self.is_completed()
-    }
-
-    /// `&dyn Kind<State = Self>` cannot do direct partial comparison
-    /// due to type opacity
-    /// so `State::new_state(self)` is called to allow a vtable lookup
-    fn kind_eq(&self, kind: &dyn Kind<State = Self>) -> bool
-    where
-        Self: Sized,
-    {
-        self.get_kind().new_state() == kind.new_state()
-    }
+    type Input: Send + Sync + 'static + fmt::Debug;
 }
 
 /// Acts as a discriminant between various [`State`] enumerations, similar to
 /// [`std::mem::Discriminant`].
 /// Used to define the scope for [`Signal`]s cycled through a [`StateMachineManager`].
-pub trait Kind: fmt::Debug + Send {
-    type State: State;
+pub trait Kind: fmt::Debug + Send + Sized {
+    type State: State<Input = Self::Input> + AsRef<Self>;
+    type Input: Send + Sync + 'static + fmt::Debug;
     fn new_state(&self) -> Self::State;
     fn failed_state(&self) -> Self::State;
     fn completed_state(&self) -> Self::State;
+    // /// represents a state that will no longer change
+    fn is_terminal(state: Self::State) -> bool {
+        let kind = state.as_ref();
+        kind.completed_state() == state || kind.failed_state() == state
+    }
 }
 
 /// Titular trait of the library that enables Hierarchical State Machine (HSM for short) behaviour.
@@ -109,13 +63,15 @@ pub trait Kind: fmt::Debug + Send {
 /// ```text
 ///
 /// Kind -> Rex::Message
-///   ::     ::       ::
-///   State  Input    Topic
+///   ::              ::
+///   State::Input    Topic
 /// ```
-pub trait Rex: Kind + HashKind {
-    type Input: Send + Sync + 'static + fmt::Debug;
+pub trait Rex: Kind + HashKind
+where
+    Self::State: AsRef<Self>,
+{
     type Message: RexMessage;
-    fn state_input(&self, state: <Self as Kind>::State) -> Option<Self::Input>;
+    fn state_input(&self, state: Self::State) -> Option<Self::Input>;
     fn timeout_input(&self, instant: Instant) -> Option<Self::Input>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ where
 }
 
 impl<K: Kind> StateId<K> {
-    pub fn new(kind: K, uuid: Uuid) -> Self {
+    pub const fn new(kind: K, uuid: Uuid) -> Self {
         Self { kind, uuid }
     }
 
@@ -129,7 +129,7 @@ impl<K: Kind> StateId<K> {
     // for testing purposes, easily distinguish UUIDs
     // by numerical value
     #[cfg(test)]
-    pub fn new_with_u128(kind: K, v: u128) -> Self {
+    pub const fn new_with_u128(kind: K, v: u128) -> Self {
         Self {
             kind,
             uuid: Uuid::from_u128(v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl<K: Kind> StateId<K> {
         Self::new(kind, Uuid::new_v4())
     }
 
-    pub fn nil(kind: K) -> Self {
+    pub const fn nil(kind: K) -> Self {
         Self::new(kind, Uuid::nil())
     }
     pub fn is_nil(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ where
             f,
             "{:?}<{}>",
             self.kind,
-            self.is_nil()
+            (!self.is_nil())
                 .then(|| bs58::encode(self.uuid).into_string())
                 .unwrap_or_else(|| "NIL".to_string())
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::module_name_repetitions)]
 use std::fmt;
 
 use bigerror::reportable;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -434,7 +434,7 @@ mod tests {
 
     // determines whether Ping or Pong will await before packet send
     //
-    #[derive(Copy, Clone, PartialEq, Debug)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub struct WhoHolds(Option<Game>);
 
     #[derive(Clone, PartialEq, Debug)]
@@ -445,7 +445,7 @@ mod tests {
         FailedPong,
     }
 
-    #[derive(Copy, Clone, PartialEq, Default, Debug)]
+    #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
     pub enum MenuState {
         #[default]
         Ready,
@@ -453,7 +453,7 @@ mod tests {
         Failed,
     }
 
-    #[derive(Copy, Clone, PartialEq, Default, Debug)]
+    #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
     pub enum PingState {
         #[default]
         Ready,
@@ -471,7 +471,7 @@ mod tests {
         RecvTimeout(Instant),
     }
 
-    #[derive(Copy, Clone, PartialEq, Default, Debug)]
+    #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
     pub enum PongState {
         #[default]
         Ready,
@@ -501,9 +501,9 @@ mod tests {
     impl AsRef<Game> for GameState {
         fn as_ref(&self) -> &Game {
             match self {
-                GameState::Ping(_) => &Game::Ping,
-                GameState::Pong(_) => &Game::Pong,
-                GameState::Menu(_) => &Game::Menu,
+                Self::Ping(_) => &Game::Ping,
+                Self::Pong(_) => &Game::Pong,
+                Self::Menu(_) => &Game::Menu,
             }
         }
     }
@@ -519,7 +519,7 @@ mod tests {
         type Message = GameMsg;
 
         fn state_input(&self, state: <Self as Kind>::State) -> Option<Self::Input> {
-            if *self != Game::Menu {
+            if *self != Self::Menu {
                 return None;
             }
 
@@ -534,9 +534,9 @@ mod tests {
 
         fn timeout_input(&self, instant: Instant) -> Option<Self::Input> {
             match self {
-                Game::Ping => Some(PingInput::RecvTimeout(instant).into()),
-                Game::Pong => Some(PongInput::RecvTimeout(instant).into()),
-                Game::Menu => None,
+                Self::Ping => Some(PingInput::RecvTimeout(instant).into()),
+                Self::Pong => Some(PongInput::RecvTimeout(instant).into()),
+                Self::Menu => None,
             }
         }
     }
@@ -544,9 +544,9 @@ mod tests {
     impl Timeout for Game {
         fn return_item(&self, item: RetainItem<Self>) -> Option<Self::Input> {
             match self {
-                Game::Ping => Some(GameInput::Ping(item.into())),
-                Game::Pong => Some(GameInput::Pong(item.into())),
-                Game::Menu => None,
+                Self::Ping => Some(GameInput::Ping(item.into())),
+                Self::Pong => Some(GameInput::Pong(item.into())),
+                Self::Menu => None,
             }
         }
     }
@@ -557,25 +557,25 @@ mod tests {
 
         fn new_state(&self) -> Self::State {
             match self {
-                Game::Ping => GameState::Ping(PingState::default()),
-                Game::Pong => GameState::Pong(PongState::default()),
-                Game::Menu => GameState::Menu(MenuState::default()),
+                Self::Ping => GameState::Ping(PingState::default()),
+                Self::Pong => GameState::Pong(PongState::default()),
+                Self::Menu => GameState::Menu(MenuState::default()),
             }
         }
 
         fn failed_state(&self) -> Self::State {
             match self {
-                Game::Ping => GameState::Ping(PingState::Failed),
-                Game::Pong => GameState::Pong(PongState::Failed),
-                Game::Menu => GameState::Menu(MenuState::Failed),
+                Self::Ping => GameState::Ping(PingState::Failed),
+                Self::Pong => GameState::Pong(PongState::Failed),
+                Self::Menu => GameState::Menu(MenuState::Failed),
             }
         }
 
         fn completed_state(&self) -> Self::State {
             match self {
-                Game::Ping => GameState::Ping(PingState::Done),
-                Game::Pong => GameState::Pong(PongState::Done),
-                Game::Menu => GameState::Menu(MenuState::Done),
+                Self::Ping => GameState::Ping(PingState::Done),
+                Self::Pong => GameState::Pong(PongState::Done),
+                Self::Menu => GameState::Menu(MenuState::Done),
             }
         }
     }
@@ -594,7 +594,7 @@ mod tests {
             };
 
             let state = ctx.get_state();
-            if let Some(true) = state.map(Game::is_terminal) {
+            if state.map(Game::is_terminal) == Some(true) {
                 warn!(%id, ?state, "Ignoring input due to invalid state");
                 return;
             }
@@ -688,7 +688,7 @@ mod tests {
                     self.set_timeout(&ctx, TEST_TIMEOUT);
                     packet.msg += 5;
 
-                    if let WhoHolds(Some(Game::Ping)) = packet.who_holds {
+                    if packet.who_holds == WhoHolds(Some(Game::Ping)) {
                         info!(msg = packet.msg, "HOLDING");
                         // hold for half theduration of the message
                         let hold_for = Duration::from_millis(packet.msg);
@@ -759,7 +759,7 @@ mod tests {
                     }
                     packet.msg += 5;
 
-                    if let WhoHolds(Some(Game::Pong)) = packet.who_holds {
+                    if packet.who_holds == WhoHolds(Some(Game::Pong)) {
                         info!(msg = packet.msg, "HOLDING");
                         // hold for half the duration of the message
                         let hold_for = Duration::from_millis(packet.msg);

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -138,6 +138,10 @@ impl<K: Rex> SmContext<K> {
         self.notification_queue.send(notification);
     }
 
+    pub fn signal_self(&self, input: K::Input) {
+        self.signal_queue.push_front(Signal { id: self.id, input });
+    }
+
     pub fn get_state(&self) -> Option<K::State> {
         let tree = self.state_store.get_tree(self.id)?;
         let guard = tree.lock();
@@ -147,6 +151,7 @@ impl<K: Rex> SmContext<K> {
     pub fn get_tree(&self) -> Option<Tree<K>> {
         self.state_store.get_tree(self.id)
     }
+
     pub fn has_state(&self) -> bool {
         self.state_store.get_tree(self.id).is_some()
     }
@@ -156,6 +161,10 @@ impl<K: Rex> SmContext<K> {
             let guard = tree.lock();
             guard.get_parent_id(self.id)
         })
+    }
+
+    pub fn has_parent(&self) -> bool {
+        self.get_parent_id().is_some()
     }
 }
 impl<K: Rex> Clone for SmContext<K> {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -60,7 +60,7 @@ use crate::{
     queue::StreamableDeque,
     storage::{StateStore, Tree},
     timeout::{RetainItem, TimeoutInput, TimeoutMessage},
-    Kind, Rex, State, StateId,
+    Kind, Rex, StateId,
 };
 
 pub trait HashKind: Kind + fmt::Debug + Hash + Eq + PartialEq + 'static + Copy
@@ -385,7 +385,7 @@ mod tests {
         notification::GetTopic,
         test_support::Hold,
         timeout::{Timeout, TimeoutMessage, TimeoutTopic, TEST_TICK_RATE, TEST_TIMEOUT},
-        Rex, RexBuilder, RexMessage,
+        Rex, RexBuilder, RexMessage, State,
     };
 
     impl From<TimeoutInput<Game>> for GameMsg {
@@ -529,7 +529,7 @@ mod tests {
                 GameState::Pong(PongState::Failed) => Some(MenuInput::FailedPong),
                 _ => None,
             }
-            .map(|i| i.into())
+            .map(std::convert::Into::into)
         }
 
         fn timeout_input(&self, instant: Instant) -> Option<Self::Input> {
@@ -867,12 +867,12 @@ mod tests {
         {
             let tree = ctx.state_store.get_tree(menu_id).unwrap();
             let node = tree.lock();
-            let ping_node = &node.children[0];
-            let pong_node = &node.children[1];
+            let ping = &node.children[0];
+            let pong = &node.children[1];
             assert_eq!(menu_id, node.id);
             assert_eq!(GameState::Menu(MenuState::Failed), node.state);
-            assert_eq!(GameState::Ping(PingState::Failed), ping_node.state);
-            assert_eq!(GameState::Pong(PongState::Failed), pong_node.state);
+            assert_eq!(GameState::Ping(PingState::Failed), ping.state);
+            assert_eq!(GameState::Pong(PongState::Failed), pong.state);
 
             // !!NOTE!! ============================================================
             // we are trying to acquire another lock...

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,6 +20,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Insert<Id> {
     pub parent_id: Option<Id>,
     pub id: Id,

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -161,7 +161,7 @@ where
     K: HashKind,
     O: Operation,
 {
-    pub fn new(id: StateId<K>, op: O) -> Self {
+    pub const fn new(id: StateId<K>, op: O) -> Self {
         Self { id, op }
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -45,7 +45,7 @@ struct RawDeque<T> {
 }
 
 impl<T> RawDeque<T> {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             front_values: VecDeque::new(),
             back_values: VecDeque::new(),
@@ -108,7 +108,7 @@ impl<T> StreamableDeque<T> {
 
     /// Returns a stream of items using `pop_front()`
     /// This opens us up to handle a `back_stream()` as well
-    pub fn stream(&self) -> StreamReceiver<T> {
+    pub const fn stream(&self) -> StreamReceiver<T> {
         StreamReceiver {
             queue: self,
             awake: None,
@@ -172,7 +172,7 @@ impl<'a, T> Drop for StreamReceiver<'a, T> {
     fn drop(&mut self) {
         let awake = self.awake.take().map(|w| w.load(Ordering::Relaxed));
 
-        if let Some(true) = awake {
+        if awake == Some(true) {
             let mut queue_wakers = self.queue.inner.lock();
             // StreamReceiver was woken by a None, notify another
             if let Some(n) = queue_wakers.rx_notifiers.pop_front() {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -162,6 +162,7 @@ impl<'a, T> Stream for StreamReceiver<'a, T> {
                 awake: awake.clone(),
             });
             self.awake = Some(awake);
+            drop(inner);
             Poll::Pending
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -37,23 +37,35 @@ impl<K: Rex> StateStore<StateId<K>, K::State> {
         }
     }
 
+    /// # Panics
+    ///
+    /// Will panic if [`StateId`] is nil
     pub fn new_tree(node: Node<StateId<K>, K::State>) -> Tree<K> {
         assert!(!node.id.is_nil());
         Arc::new(FairMutex::new(node))
     }
 
-    // insert node creates a new reference to the same node
+    /// insert node creates a new reference to the same node
+    /// # Panics
+    ///
+    /// Will panic if [`StateId`] is nil
     pub fn insert_ref(&self, id: StateId<K>, node: Tree<K>) {
         assert!(!id.is_nil());
         self.trees.insert(id, node);
     }
 
     // decrements the reference count on a given `Node`
+    /// # Panics
+    ///
+    /// Will panic if [`StateId`] is nil
     pub fn remove_ref(&self, id: StateId<K>) {
         assert!(!id.is_nil());
         self.trees.remove(&id);
     }
 
+    /// # Panics
+    ///
+    /// Will panic if [`StateId`] is nil
     pub fn get_tree(&self, id: StateId<K>) -> Option<Tree<K>> {
         assert!(!id.is_nil());
         let node = self.trees.get(&id);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,7 +10,7 @@ use crate::{node::Node, Kind, Rex, StateId};
 /// this allows separate state hirearchies to be acted upon concurrently
 /// while making operations in a particular tree blocking
 pub struct StateStore<Id, S> {
-    pub trees: DashMap<Id, Arc<FairMutex<Node<Id, S>>>>,
+    trees: DashMap<Id, Arc<FairMutex<Node<Id, S>>>>,
 }
 
 impl<K> Default for StateStore<StateId<K>, K::State>
@@ -38,20 +38,24 @@ impl<K: Rex> StateStore<StateId<K>, K::State> {
     }
 
     pub fn new_tree(node: Node<StateId<K>, K::State>) -> Tree<K> {
+        assert!(!node.id.is_nil());
         Arc::new(FairMutex::new(node))
     }
 
     // insert node creates a new reference to the same node
     pub fn insert_ref(&self, id: StateId<K>, node: Tree<K>) {
+        assert!(!id.is_nil());
         self.trees.insert(id, node);
     }
 
     // decrements the reference count on a given `Node`
     pub fn remove_ref(&self, id: StateId<K>) {
+        assert!(!id.is_nil());
         self.trees.remove(&id);
     }
 
     pub fn get_tree(&self, id: StateId<K>) -> Option<Tree<K>> {
+        assert!(!id.is_nil());
         let node = self.trees.get(&id);
         node.map(|n| n.value().clone())
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -38,15 +38,18 @@ macro_rules! node_state {
         }
 
         impl State for NodeState {
-            fn get_kind(&self) -> &dyn Kind<State = NodeState> {
+            type Input = ();
+        }
+        impl AsRef<NodeKind> for NodeState {
+            fn as_ref(&self) -> &NodeKind {
                 match self {
-                    $( NodeState::$name(_) => &NodeKind::$name, )*
+                    $( Self::$name(_) => &NodeKind::$name, )*
                 }
             }
         }
-
         impl Kind for NodeKind {
             type State = NodeState;
+            type Input = ();
 
             fn new_state(&self) -> Self::State {
                 match self {
@@ -115,7 +118,11 @@ pub enum TestState {
 }
 
 impl State for TestState {
-    fn get_kind(&self) -> &dyn Kind<State = TestState> {
+    type Input = TestInput;
+}
+
+impl AsRef<TestKind> for TestState {
+    fn as_ref(&self) -> &TestKind {
         &TestKind
     }
 }
@@ -125,6 +132,7 @@ pub struct TestKind;
 
 impl Kind for TestKind {
     type State = TestState;
+    type Input = TestInput;
 
     fn new_state(&self) -> Self::State {
         TestState::New
@@ -166,7 +174,6 @@ pub struct OutPacket(pub Vec<u8>);
 pub struct InPacket(pub Vec<u8>);
 
 impl Rex for TestKind {
-    type Input = TestInput;
     type Message = TestMsg;
 
     fn state_input(&self, _state: <Self as Kind>::State) -> Option<Self::Input> {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -161,7 +161,7 @@ impl TryFrom<InPacket> for TestInput {
 }
 impl Timeout for TestKind {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TestInput {
     Timeout(Instant),
     Packet(InPacket),

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -101,9 +101,9 @@ impl TimeoutMessage<TestKind> for TestMsg {
 impl GetTopic<TestTopic> for TestMsg {
     fn get_topic(&self) -> TestTopic {
         match self {
-            TestMsg::TimeoutInput(_) => TestTopic::Timeout,
-            TestMsg::Ingress(_) => TestTopic::Ingress,
-            TestMsg::Other => TestTopic::Other,
+            Self::TimeoutInput(_) => TestTopic::Timeout,
+            Self::Ingress(_) => TestTopic::Ingress,
+            Self::Other => TestTopic::Other,
         }
     }
 }
@@ -170,7 +170,7 @@ pub enum TestInput {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OutPacket(pub Vec<u8>);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InPacket(pub Vec<u8>);
 
 impl Rex for TestKind {
@@ -205,7 +205,7 @@ impl StateRouter<TestKind> for TestStateRouter {
 impl<'a> TryFrom<&'a InPacket> for TestKind {
     type Error = Report<ConversionError>;
     fn try_from(_value: &'a InPacket) -> Result<Self, Self::Error> {
-        Ok(TestKind)
+        Ok(Self)
     }
 }
 
@@ -233,12 +233,12 @@ impl TryInto<TimeoutInput<TestKind>> for TestMsg {
 
 impl From<OutPacket> for TestMsg {
     fn from(val: OutPacket) -> Self {
-        TestMsg::Ingress(val)
+        Self::Ingress(val)
     }
 }
 
 impl From<TimeoutInput<TestKind>> for TestMsg {
     fn from(value: TimeoutInput<TestKind>) -> Self {
-        TestMsg::TimeoutInput(value)
+        Self::TimeoutInput(value)
     }
 }

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -313,7 +313,7 @@ where
                                     ledger.set_timeout(id, instant);
                                 }
                                 Operation::Retain(item, instant) => {
-                                    ledger.retain(id, instant, item)
+                                    ledger.retain(id, instant, item);
                                 }
                             }
                         }

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -355,6 +355,7 @@ where
 
                     let mut release = ledger.retainer.split_off(&now);
                     std::mem::swap(&mut release, &mut ledger.retainer);
+                    drop(ledger);
                     for (id, item) in release.into_values().flat_map(IntoIterator::into_iter) {
                         if let Some(input) = id.return_item(item) {
                             // caveat with this push_front setup is

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -178,9 +178,9 @@ pub enum Operation<T> {
 impl<T> std::fmt::Display for Operation<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let op = match self {
-            Operation::Cancel => "timeout::Cancel",
-            Operation::Set(_) => "timeout::Set",
-            Operation::Retain(_, _) => "timeout::Retain",
+            Self::Cancel => "timeout::Cancel",
+            Self::Set(_) => "timeout::Set",
+            Self::Retain(_, _) => "timeout::Retain",
         };
         write!(f, "{op}")
     }
@@ -222,7 +222,7 @@ where
         }
     }
 
-    pub fn cancel_timeout(id: StateId<K>) -> Self {
+    pub const fn cancel_timeout(id: StateId<K>) -> Self {
         Self {
             id,
             op: Operation::Cancel,
@@ -237,11 +237,11 @@ where
     }
 
     #[cfg(test)]
-    fn with_id(&self, id: StateId<K>) -> Self {
+    const fn with_id(&self, id: StateId<K>) -> Self {
         Self { id, ..*self }
     }
     #[cfg(test)]
-    fn with_op(&self, op: TimeoutOp<K>) -> Self {
+    const fn with_op(&self, op: TimeoutOp<K>) -> Self {
         Self { op, ..*self }
     }
 }
@@ -338,15 +338,10 @@ where
                     let now = Instant::now();
                     let mut ledger = timer_ledger.lock();
                     // Get all instants where `instant <= now`
-                    let expired: Vec<Instant> =
-                        ledger.timers.range(..=now).map(|(k, _)| *k).collect();
+                    let mut release = ledger.timers.split_off(&now);
+                    std::mem::swap(&mut release, &mut ledger.timers);
 
-                    for id in expired
-                        .iter()
-                        .filter_map(|t| ledger.timers.remove(t))
-                        .flat_map(IntoIterator::into_iter)
-                        .collect::<Vec<_>>()
-                    {
+                    for id in release.into_values().flat_map(IntoIterator::into_iter) {
                         warn!(%id, "timed out");
                         ledger.ids.remove(&id);
                         if let Some(input) = id.timeout_input(now) {
@@ -360,11 +355,7 @@ where
 
                     let mut release = ledger.retainer.split_off(&now);
                     std::mem::swap(&mut release, &mut ledger.retainer);
-                    for (id, item) in release
-                        .into_values()
-                        .flat_map(IntoIterator::into_iter)
-                        .collect::<Vec<_>>()
-                    {
+                    for (id, item) in release.into_values().flat_map(IntoIterator::into_iter) {
                         if let Some(input) = id.return_item(item) {
                             // caveat with this push_front setup is
                             // that later timeouts will be on top of the stack
@@ -415,7 +406,7 @@ mod tests {
     impl TestDefault for TimeoutManager<TestKind> {
         fn test_default() -> Self {
             let signal_queue = SignalQueue::default();
-            TimeoutManager::new(signal_queue, TestTopic::Timeout).with_tick_rate(TEST_TICK_RATE)
+            Self::new(signal_queue, TestTopic::Timeout).with_tick_rate(TEST_TICK_RATE)
         }
     }
 


### PR DESCRIPTION
Refactored state trait so that it holds an `Input` associated type:
https://github.com/knox-networks/rex-sm/blob/534388dc518bb0d7349b091f732cc058984c1c57/src/lib.rs#L32-L37

This allows a state/input association to be held at a lower level than `Kind` allowing inner states & inputs to have their own logic without implementing `Rex` or `Kind`